### PR TITLE
#164035808 Implements create red-flag and intervention reports

### DIFF
--- a/src/actions/reportAction.js
+++ b/src/actions/reportAction.js
@@ -1,0 +1,37 @@
+import typeGenerator from './actionTypes';
+import request from '../utils/request';
+
+export const createReportTypes = typeGenerator('CREATE_REPORT');
+
+/**
+ * Action creator for login and signup operations
+ * @param {string} type The action type
+ * @param {object} data The data to dispatch
+ */
+export const createReportAction = (type, data) => ({ type, data });
+
+/**
+ * Creates or edit a report
+ * @param {object} payload An object containing the request parameters
+ * @returns {object} The axios request promise object
+ */
+const reportIncident = payload => async (dispatch) => {
+  dispatch(createReportAction(createReportTypes.loading, true));
+  return request({
+    route: payload.route,
+    method: payload.method,
+    payload,
+  }).then((response) => {
+    const { data } = response.data;
+    const { message } = { ...data[0] };
+    dispatch(createReportAction(createReportTypes.success, message));
+  }).catch((err) => {
+    let message = ['Please check your network connection'];
+    if (err.response) {
+      const { data: { error } } = err.response;
+      message = error;
+    }
+    dispatch(createReportAction(createReportTypes.failure, message));
+  });
+};
+export default reportIncident;

--- a/src/components/containers/CreateReportContainer.jsx
+++ b/src/components/containers/CreateReportContainer.jsx
@@ -1,0 +1,60 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import formDataJSON from 'formdata-json';
+import PropTypes from 'prop-types';
+import { createStructuredSelector } from 'reselect';
+import { Redirect } from 'react-router-dom';
+import { getUser, getReport } from '../../selectors';
+import { scrollTop } from '../../utils/helpers';
+import CreateReport from '../views/CreateReport';
+import reportIncident from '../../actions/reportAction';
+
+
+/**
+ * Container component for the create report view
+ * @export
+ * @class CreateReport
+ * @extends {Component}
+ */
+class CreateReportContainer extends Component {
+  handleSubmit = async (event) => {
+    event.preventDefault();
+    const payload = formDataJSON(new FormData(event.target));
+    payload.route = `${payload.type}s`;
+    payload.method = payload.id ? 'patch' : 'post';
+    payload.location = `${payload.latitude},${payload.longitude}`;
+    const { reportIncident: processReportIncident } = this.props;
+    await processReportIncident(payload);
+    scrollTop();
+  }
+
+  render() {
+    const { user, report } = this.props;
+    if (!user.isLoggedIn) return <Redirect to="/login" />;
+    if (report.success) return <Redirect to="/dashboard" />;
+    return (
+      <CreateReport
+      handleSubmit={this.handleSubmit}
+      report={report}
+      />
+    );
+  }
+}
+CreateReportContainer.propTypes = {
+  user: PropTypes.object.isRequired,
+  report: PropTypes.object.isRequired,
+  reportIncident: PropTypes.func.isRequired,
+};
+
+const mapStateToProps = createStructuredSelector(
+  {
+    user: getUser,
+    report: getReport
+  }
+);
+
+const mapDispatchToProps = dispatch => ({
+  reportIncident: payload => dispatch(reportIncident(payload)),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(CreateReportContainer);

--- a/src/components/containers/ProfileContainer.jsx
+++ b/src/components/containers/ProfileContainer.jsx
@@ -27,14 +27,6 @@ class ProfileContainer extends Component {
     scrollTop();
   }
 
-  handleChangePassword = async (event) => {
-    event.preventDefault();
-    const payload = formDataJSON(new FormData(event.target));
-    payload.route = 'users/password';
-    payload.method = 'patch';
-    scrollTop();
-  }
-
   render() {
     const { user } = this.props;
     if (!user.isLoggedIn) return <Redirect to="/login" />;

--- a/src/components/views/CreateReport.jsx
+++ b/src/components/views/CreateReport.jsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import PropTypes from 'prop-types';
+import loadingIcon from '../../../public/images/resources/loader-light.gif';
+import Alert from './Alert';
+
+/**
+ * The create report component
+ * @returns {object} The generated JSX object
+ */
+export default function CreateReport({ handleSubmit, report }) {
+  return (
+    <section className="login-wrapper top-space account-wrapper" data-pg-name="Dashboard">
+      <section className="heading">
+        <div className="wrapper" data-pg-name="Wrapper">
+          <div className="max-width-800">
+            <div className="bread">
+              <h1>Report an Incident</h1>
+            </div>
+          </div>
+        </div>
+      </section>
+      <div className="wrapper" data-pg-name="Wrapper">
+        <form onSubmit={handleSubmit} noValidate>
+          {report.message.length > 0 && <Alert message={report.message} title={report.success ? 'Report Successful!' : 'Oops!'} success={report.success} />}
+          <div className="report-item card card-sm max-width-800 create-report-details">
+            <div className="form-wrapper">
+              <label htmlFor="title">Title </label>
+              <small className="text-helper">(e.g Power outage for over 3 weeks around Aba market)</small>
+              <input id="title" className="form-element" type="text" name="title" required defaultValue={report.title} />
+            </div>
+            <div className="form-wrapper no-margin-btm">
+              <label htmlFor="comments">
+Comment
+              </label>
+              <small className="text-helper">(Write full details here)</small>
+              <textarea id="comments" className="form-element" name="comment" required defaultValue={report.comment} />
+            </div>
+          </div>
+          <div className="report-item card card-sm max-width-800 create-report-details padding-zero-btm">
+            <h2 className="report-box-title">Report Type</h2>
+            <p>
+Is this incident linked to corruption or
+              just an issue that needs government intervention ?
+
+            </p>
+            <div className="row" data-pg-name="Row">
+              <div className="column column-md-6" data-pg-name="Column">
+                <div className="report-item max-width-800 report-box card no-margin-btm" title="Red Flag Report">
+                  <h4>
+Corruption case
+                    {' '}
+                    <i className="fa fa-flag flag" title="Red Flag Report" />
+                  </h4>
+                  <p>e.g. bribery, extortion, money laundering, e.t.c</p>
+                  <input type="radio" name="type" defaultValue="red-flag" data-pg-hidden className="radio-fine" defaultChecked />
+                  <div className="pg-empty-placeholder radio-mark" />
+                </div>
+              </div>
+              <div className="column column-md-6" data-pg-name="Column">
+                <div className="report-item max-width-800 report-box card" title="Intervention Report">
+                  <h4>
+Intervention Case
+                    {' '}
+                    <i className="fa flag fa-bullhorn flag-intervention" title="Intervention Report" />
+                  </h4>
+                  <p>e.g. bad road, collapsed bridge, flooding, e.t.c</p>
+                  <input type="radio" name="type" defaultValue="intervention" className="radio-fine" data-pg-hidden defaultChecked={report.type === 'intervention'} />
+                  <div className="pg-empty-placeholder radio-mark" />
+                </div>
+              </div>
+            </div>
+          </div>
+          <div className="report-item card card-sm max-width-800 create-report-details padding-zero-btm">
+            <header className="header-create">
+              <h2 className="report-box-title">Location</h2>
+              <p>
+Where did this happen? Enter the latitude/longitude. You can use
+                {' '}
+                <Link to="https://maps.google.com" target="_blank"><strong><ins>Google Map</ins></strong></Link>
+                {' '}
+for help.
+              </p>
+              <p className="hidden">Where did this happen? Enter the latitude/longitude or simply use the marker to choose a location from the map</p>
+            </header>
+            <div className="row" data-pg-name="Row">
+              <div className="column-md-6 column column-xs-6" data-pg-name="column-md-6">
+                <div className="form-wrapper">
+                  <label htmlFor="latitude">Latitude</label>
+                  <input id="latitude" defaultValue={report.latitude} className="form-element" type="tel" name="latitude" required />
+                </div>
+              </div>
+              <div className="column-md-6 column column-xs-6" data-pg-name="column-md-6">
+                <div className="form-wrapper">
+                  <label htmlFor="longitude">Longitude</label>
+                  <input id="longitude" defaultValue={report.longitude} className="form-element" type="tel" name="longitude" required />
+                </div>
+              </div>
+            </div>
+          </div>
+          <div className="btn-wrapper max-width-800">
+            <button disabled={report.isBusy} className="btn-brand btn-250 btn-submit" type="submit">
+              <span>Submit Report</span>
+              { report.isBusy && <img src={loadingIcon} width="12" alt="loading" />}
+            </button>
+          </div>
+        </form>
+      </div>
+    </section>
+
+  );
+}
+
+CreateReport.propTypes = {
+  handleSubmit: PropTypes.func.isRequired,
+  report: PropTypes.object.isRequired
+};

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -13,7 +13,7 @@ import Landing from './components/views/Landing';
 import LoginContainer from './components/containers/LoginContainer';
 import SignupContainer from './components/containers/SignupContainer';
 import ProfileContainer from './components/containers/ProfileContainer';
-
+import CreateReportContainer from './components/containers/CreateReportContainer';
 
 const { store, persistor } = reduxStore;
 
@@ -31,9 +31,10 @@ function App() {
             <HeaderContainer />
             <Switch>
               <Route path="/" component={Landing} exact />
-              <Route path="/login" component={LoginContainer} />
-              <Route path="/sign-up" component={SignupContainer} />
-              <Route path="/profile" component={ProfileContainer} />
+              <Route path="/login" component={LoginContainer} exact />
+              <Route path="/sign-up" component={SignupContainer} exact />
+              <Route path="/profile" component={ProfileContainer} exact />
+              <Route path="/create-report" component={CreateReportContainer} exact />
             </Switch>
             <Footer />
           </>

--- a/src/reducers/createReportReducer.js
+++ b/src/reducers/createReportReducer.js
@@ -1,0 +1,27 @@
+import { createReportTypes } from '../actions/reportAction';
+
+/**
+ * A reducer that formats the data before updating the redux store with the new state
+ * @param {object} state A copy of the redux state
+ * @param {object} action The action containing the type and values to be used to update the store
+ * @returns {object} The expected new state of the redux store
+ */
+export default (state = {}, action) => {
+  const { type, data } = action;
+  switch (type) {
+    case createReportTypes.loading:
+      return {
+        ...state, isBusy: true, message: []
+      };
+    case createReportTypes.success:
+      return {
+        ...state, message: [data], success: true, isBusy: false
+      };
+    case createReportTypes.failure:
+      return {
+        ...state, isBusy: false, message: data, success: false
+      };
+    default:
+      return state;
+  }
+};

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,9 +1,10 @@
 import { combineReducers } from 'redux';
 import authReducer from './authReducer';
-
+import reportReducer from './createReportReducer';
 /**
  * @function combineReducers - the redux store combineReducers function
  */
 export default combineReducers({
   user: authReducer,
+  report: reportReducer,
 });

--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -5,9 +5,11 @@ import { createSelector } from 'reselect';
  * @param {object} state A reference to the state in the redux store
  */
 export const userSelector = state => state.user;
+export const createReport = state => state.report;
 
 
 /**
  * Selectors created by the reselect library for memoized functions
  */
 export const getUser = createSelector(userSelector, user => user);
+export const getReport = createSelector(createReport, report => report);

--- a/src/store/initialState.js
+++ b/src/store/initialState.js
@@ -4,5 +4,10 @@ export default {
     message: [],
     success: false,
     isLoggedIn: false,
+  },
+  report: {
+    message: [],
+    isBusy: false,
+    success: false,
   }
 };

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -1,8 +1,8 @@
 @import './shared.scss';
 @import './home.scss';
+@import './dialog.scss';
 @import './form.scss';
 @import './login.scss';
 @import './admin.scss';
-@import './dialog.scss';
 @import './user.scss';
 @import './reports-card.scss';

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -4,5 +4,5 @@
 @import './login.scss';
 @import './admin.scss';
 @import './dialog.scss';
-@import './reports-card.scss';
 @import './user.scss';
+@import './reports-card.scss';

--- a/test/actions/createReportActon.test.js
+++ b/test/actions/createReportActon.test.js
@@ -1,0 +1,76 @@
+import '@babel/polyfill';
+import reportIncident, { createReportTypes, createReportAction } from '../../src/actions/reportAction';
+import { createMockStore } from '../setup';
+import request from '../../src/utils/request';
+
+const mockStore = createMockStore();
+
+jest.mock('../../src/utils/request');
+
+describe('Create report Action creators', () => {
+  it('should return an object of the create article action types', () => {
+    const expected = {
+      type: createReportTypes.loading,
+      data: true,
+    };
+    expect(createReportAction(createReportTypes.loading, true)).toEqual(expected);
+  });
+  it('should return the correct value on successful create report request', () => {
+    const response = { message: 'successful' };
+    const expected = [
+      {
+        type: createReportTypes.loading,
+        data: true,
+      },
+      {
+        type: createReportTypes.success,
+        data: 'successful'
+      }
+    ];
+    request.mockResolvedValue({ data: { data: [response] } });
+
+    const store = mockStore();
+
+    return store.dispatch(reportIncident({})).then(() => {
+      expect(store.getActions()).toEqual(expected);
+    });
+  });
+  it('should return the correct value on failed create report request', () => {
+    const expected = [
+      {
+        type: createReportTypes.loading,
+        data: true,
+      },
+      {
+        type: createReportTypes.failure,
+        data: ['failed']
+      }
+    ];
+    request.mockRejectedValue({ response: { data: { error: ['failed'] } } });
+
+    const store = mockStore();
+
+    return store.dispatch(reportIncident({})).then(() => {
+      expect(store.getActions()).toEqual(expected);
+    });
+  });
+  it('should return the correct value for unknown error', () => {
+    const expected = [
+      {
+        type: createReportTypes.loading,
+        data: true,
+      },
+      {
+        type: createReportTypes.failure,
+        data: ['Please check your network connection']
+      }
+    ];
+    request.mockRejectedValue({});
+
+    const store = mockStore();
+
+    return store.dispatch(reportIncident({})).then(() => {
+      expect(store.getActions()).toEqual(expected);
+    });
+  });
+});

--- a/test/containers/CreateReportContainer.test.js
+++ b/test/containers/CreateReportContainer.test.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import setup from '../setup';
+import CreateReportContainer from '../../src/components/containers/CreateReportContainer';
+
+
+describe('<CreateReportContainer>', () => {
+  it('should render without crashing', () => {
+    const wrapper = setup(<CreateReportContainer />);
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/test/containers/__snapshots__/CreateReportContainer.test.js.snap
+++ b/test/containers/__snapshots__/CreateReportContainer.test.js.snap
@@ -1,0 +1,66 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<CreateReportContainer> should render without crashing 1`] = `
+<Provider
+  store={
+    Object {
+      "clearActions": [Function],
+      "dispatch": [Function],
+      "getActions": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+    }
+  }
+>
+  <BrowserRouter
+    keyLength={0}
+  >
+    <Router
+      history={
+        Object {
+          "action": "REPLACE",
+          "block": [Function],
+          "createHref": [Function],
+          "go": [Function],
+          "goBack": [Function],
+          "goForward": [Function],
+          "length": 1,
+          "listen": [Function],
+          "location": Object {
+            "hash": "",
+            "pathname": "/login",
+            "search": "",
+            "state": undefined,
+          },
+          "push": [Function],
+          "replace": [Function],
+        }
+      }
+    >
+      <Connect(CreateReportContainer)>
+        <CreateReportContainer
+          report={
+            Object {
+              "message": Array [],
+            }
+          }
+          reportIncident={[Function]}
+          user={
+            Object {
+              "isBusy": false,
+              "message": Array [],
+              "success": false,
+            }
+          }
+        >
+          <Redirect
+            push={false}
+            to="/login"
+          />
+        </CreateReportContainer>
+      </Connect(CreateReportContainer)>
+    </Router>
+  </BrowserRouter>
+</Provider>
+`;

--- a/test/reducers/createReportReducer.test.js
+++ b/test/reducers/createReportReducer.test.js
@@ -1,0 +1,26 @@
+import '@babel/polyfill';
+import { mockState } from '../setup';
+import createReportReducer from '../../src/reducers/createReportReducer';
+import { createReportTypes } from '../../src/actions/reportAction';
+
+
+describe('Create report Reducer', () => {
+  it('should return the initial state', () => {
+    expect(createReportReducer(mockState, {})).toEqual(mockState);
+  });
+  it('should return the initial state if it is not set', () => {
+    expect(createReportReducer(undefined, {})).toEqual({});
+  });
+  it('should return the correct state when loading', () => {
+    const action = { type: createReportTypes.loading, data: true };
+    expect(createReportReducer({}, action)).toEqual({ isBusy: true, message: [] });
+  });
+  it('should return the correct state on success', () => {
+    const action = { type: createReportTypes.success, data: 'success' };
+    expect(createReportReducer({}, action)).toEqual({ message: ['success'], success: true, isBusy: false });
+  });
+  it('should return the correct state on failure', () => {
+    const action = { type: createReportTypes.failure, data: ['failed'] };
+    expect(createReportReducer({}, action)).toEqual({ message: ['failed'], success: false, isBusy: false });
+  });
+});

--- a/test/setup.js
+++ b/test/setup.js
@@ -13,6 +13,9 @@ export const mockState = {
     isBusy: false,
     message: [],
     success: false
+  },
+  report: {
+    message: []
   }
 };
 

--- a/test/views/CreateReport.test.js
+++ b/test/views/CreateReport.test.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import CreateReport from '../../src/components/views/CreateReport';
+
+describe('<CreateReport>', () => {
+  it('should render without crashing for red-flag report', () => {
+    const wrapper = shallow(<CreateReport
+handleSubmit={jest.fn()} report={{
+  message: [],
+  success: false,
+  isBusy: false,
+  type: 'red-flag'
+}} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+  it('should render without crashing for intervention report', () => {
+    const wrapper = shallow(<CreateReport
+handleSubmit={jest.fn()} report={{
+  message: [],
+  success: false,
+  isBusy: false,
+  type: 'intervention'
+}} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+  it('should render without crashing for successful report', () => {
+    const wrapper = shallow(<CreateReport
+handleSubmit={jest.fn()} report={{
+  message: ['successful'],
+  success: true,
+  isBusy: false,
+  type: 'intervention'
+}} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+  it('should render without crashing for failed report', () => {
+    const wrapper = shallow(<CreateReport
+handleSubmit={jest.fn()} report={{
+  message: ['failed'],
+  success: false,
+  isBusy: true,
+  type: 'red-flag'
+}} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/test/views/__snapshots__/CreateReport.test.js.snap
+++ b/test/views/__snapshots__/CreateReport.test.js.snap
@@ -1,0 +1,1060 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<CreateReport> should render without crashing for failed report 1`] = `
+<section
+  className="login-wrapper top-space account-wrapper"
+  data-pg-name="Dashboard"
+>
+  <section
+    className="heading"
+  >
+    <div
+      className="wrapper"
+      data-pg-name="Wrapper"
+    >
+      <div
+        className="max-width-800"
+      >
+        <div
+          className="bread"
+        >
+          <h1>
+            Report an Incident
+          </h1>
+        </div>
+      </div>
+    </div>
+  </section>
+  <div
+    className="wrapper"
+    data-pg-name="Wrapper"
+  >
+    <form
+      noValidate={true}
+      onSubmit={[MockFunction]}
+    >
+      <Alert
+        message={
+          Array [
+            "failed",
+          ]
+        }
+        success={false}
+        title="Oops!"
+      />
+      <div
+        className="report-item card card-sm max-width-800 create-report-details"
+      >
+        <div
+          className="form-wrapper"
+        >
+          <label
+            htmlFor="title"
+          >
+            Title 
+          </label>
+          <small
+            className="text-helper"
+          >
+            (e.g Power outage for over 3 weeks around Aba market)
+          </small>
+          <input
+            className="form-element"
+            id="title"
+            name="title"
+            required={true}
+            type="text"
+          />
+        </div>
+        <div
+          className="form-wrapper no-margin-btm"
+        >
+          <label
+            htmlFor="comments"
+          >
+            Comment
+          </label>
+          <small
+            className="text-helper"
+          >
+            (Write full details here)
+          </small>
+          <textarea
+            className="form-element"
+            id="comments"
+            name="comment"
+            required={true}
+          />
+        </div>
+      </div>
+      <div
+        className="report-item card card-sm max-width-800 create-report-details padding-zero-btm"
+      >
+        <h2
+          className="report-box-title"
+        >
+          Report Type
+        </h2>
+        <p>
+          Is this incident linked to corruption or just an issue that needs government intervention ?
+        </p>
+        <div
+          className="row"
+          data-pg-name="Row"
+        >
+          <div
+            className="column column-md-6"
+            data-pg-name="Column"
+          >
+            <div
+              className="report-item max-width-800 report-box card no-margin-btm"
+              title="Red Flag Report"
+            >
+              <h4>
+                Corruption case
+                 
+                <i
+                  className="fa fa-flag flag"
+                  title="Red Flag Report"
+                />
+              </h4>
+              <p>
+                e.g. bribery, extortion, money laundering, e.t.c
+              </p>
+              <input
+                className="radio-fine"
+                data-pg-hidden={true}
+                defaultChecked={true}
+                defaultValue="red-flag"
+                name="type"
+                type="radio"
+              />
+              <div
+                className="pg-empty-placeholder radio-mark"
+              />
+            </div>
+          </div>
+          <div
+            className="column column-md-6"
+            data-pg-name="Column"
+          >
+            <div
+              className="report-item max-width-800 report-box card"
+              title="Intervention Report"
+            >
+              <h4>
+                Intervention Case
+                 
+                <i
+                  className="fa flag fa-bullhorn flag-intervention"
+                  title="Intervention Report"
+                />
+              </h4>
+              <p>
+                e.g. bad road, collapsed bridge, flooding, e.t.c
+              </p>
+              <input
+                className="radio-fine"
+                data-pg-hidden={true}
+                defaultChecked={false}
+                defaultValue="intervention"
+                name="type"
+                type="radio"
+              />
+              <div
+                className="pg-empty-placeholder radio-mark"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="report-item card card-sm max-width-800 create-report-details padding-zero-btm"
+      >
+        <header
+          className="header-create"
+        >
+          <h2
+            className="report-box-title"
+          >
+            Location
+          </h2>
+          <p>
+            Where did this happen? Enter the latitude/longitude. You can use
+             
+            <Link
+              replace={false}
+              target="_blank"
+              to="https://maps.google.com"
+            >
+              <strong>
+                <ins>
+                  Google Map
+                </ins>
+              </strong>
+            </Link>
+             
+            for help.
+          </p>
+          <p
+            className="hidden"
+          >
+            Where did this happen? Enter the latitude/longitude or simply use the marker to choose a location from the map
+          </p>
+        </header>
+        <div
+          className="row"
+          data-pg-name="Row"
+        >
+          <div
+            className="column-md-6 column column-xs-6"
+            data-pg-name="column-md-6"
+          >
+            <div
+              className="form-wrapper"
+            >
+              <label
+                htmlFor="latitude"
+              >
+                Latitude
+              </label>
+              <input
+                className="form-element"
+                id="latitude"
+                name="latitude"
+                required={true}
+                type="tel"
+              />
+            </div>
+          </div>
+          <div
+            className="column-md-6 column column-xs-6"
+            data-pg-name="column-md-6"
+          >
+            <div
+              className="form-wrapper"
+            >
+              <label
+                htmlFor="longitude"
+              >
+                Longitude
+              </label>
+              <input
+                className="form-element"
+                id="longitude"
+                name="longitude"
+                required={true}
+                type="tel"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="btn-wrapper max-width-800"
+      >
+        <button
+          className="btn-brand btn-250 btn-submit"
+          disabled={true}
+          type="submit"
+        >
+          <span>
+            Submit Report
+          </span>
+          <img
+            alt="loading"
+            src={Object {}}
+            width="12"
+          />
+        </button>
+      </div>
+    </form>
+  </div>
+</section>
+`;
+
+exports[`<CreateReport> should render without crashing for intervention report 1`] = `
+<section
+  className="login-wrapper top-space account-wrapper"
+  data-pg-name="Dashboard"
+>
+  <section
+    className="heading"
+  >
+    <div
+      className="wrapper"
+      data-pg-name="Wrapper"
+    >
+      <div
+        className="max-width-800"
+      >
+        <div
+          className="bread"
+        >
+          <h1>
+            Report an Incident
+          </h1>
+        </div>
+      </div>
+    </div>
+  </section>
+  <div
+    className="wrapper"
+    data-pg-name="Wrapper"
+  >
+    <form
+      noValidate={true}
+      onSubmit={[MockFunction]}
+    >
+      <div
+        className="report-item card card-sm max-width-800 create-report-details"
+      >
+        <div
+          className="form-wrapper"
+        >
+          <label
+            htmlFor="title"
+          >
+            Title 
+          </label>
+          <small
+            className="text-helper"
+          >
+            (e.g Power outage for over 3 weeks around Aba market)
+          </small>
+          <input
+            className="form-element"
+            id="title"
+            name="title"
+            required={true}
+            type="text"
+          />
+        </div>
+        <div
+          className="form-wrapper no-margin-btm"
+        >
+          <label
+            htmlFor="comments"
+          >
+            Comment
+          </label>
+          <small
+            className="text-helper"
+          >
+            (Write full details here)
+          </small>
+          <textarea
+            className="form-element"
+            id="comments"
+            name="comment"
+            required={true}
+          />
+        </div>
+      </div>
+      <div
+        className="report-item card card-sm max-width-800 create-report-details padding-zero-btm"
+      >
+        <h2
+          className="report-box-title"
+        >
+          Report Type
+        </h2>
+        <p>
+          Is this incident linked to corruption or just an issue that needs government intervention ?
+        </p>
+        <div
+          className="row"
+          data-pg-name="Row"
+        >
+          <div
+            className="column column-md-6"
+            data-pg-name="Column"
+          >
+            <div
+              className="report-item max-width-800 report-box card no-margin-btm"
+              title="Red Flag Report"
+            >
+              <h4>
+                Corruption case
+                 
+                <i
+                  className="fa fa-flag flag"
+                  title="Red Flag Report"
+                />
+              </h4>
+              <p>
+                e.g. bribery, extortion, money laundering, e.t.c
+              </p>
+              <input
+                className="radio-fine"
+                data-pg-hidden={true}
+                defaultChecked={true}
+                defaultValue="red-flag"
+                name="type"
+                type="radio"
+              />
+              <div
+                className="pg-empty-placeholder radio-mark"
+              />
+            </div>
+          </div>
+          <div
+            className="column column-md-6"
+            data-pg-name="Column"
+          >
+            <div
+              className="report-item max-width-800 report-box card"
+              title="Intervention Report"
+            >
+              <h4>
+                Intervention Case
+                 
+                <i
+                  className="fa flag fa-bullhorn flag-intervention"
+                  title="Intervention Report"
+                />
+              </h4>
+              <p>
+                e.g. bad road, collapsed bridge, flooding, e.t.c
+              </p>
+              <input
+                className="radio-fine"
+                data-pg-hidden={true}
+                defaultChecked={true}
+                defaultValue="intervention"
+                name="type"
+                type="radio"
+              />
+              <div
+                className="pg-empty-placeholder radio-mark"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="report-item card card-sm max-width-800 create-report-details padding-zero-btm"
+      >
+        <header
+          className="header-create"
+        >
+          <h2
+            className="report-box-title"
+          >
+            Location
+          </h2>
+          <p>
+            Where did this happen? Enter the latitude/longitude. You can use
+             
+            <Link
+              replace={false}
+              target="_blank"
+              to="https://maps.google.com"
+            >
+              <strong>
+                <ins>
+                  Google Map
+                </ins>
+              </strong>
+            </Link>
+             
+            for help.
+          </p>
+          <p
+            className="hidden"
+          >
+            Where did this happen? Enter the latitude/longitude or simply use the marker to choose a location from the map
+          </p>
+        </header>
+        <div
+          className="row"
+          data-pg-name="Row"
+        >
+          <div
+            className="column-md-6 column column-xs-6"
+            data-pg-name="column-md-6"
+          >
+            <div
+              className="form-wrapper"
+            >
+              <label
+                htmlFor="latitude"
+              >
+                Latitude
+              </label>
+              <input
+                className="form-element"
+                id="latitude"
+                name="latitude"
+                required={true}
+                type="tel"
+              />
+            </div>
+          </div>
+          <div
+            className="column-md-6 column column-xs-6"
+            data-pg-name="column-md-6"
+          >
+            <div
+              className="form-wrapper"
+            >
+              <label
+                htmlFor="longitude"
+              >
+                Longitude
+              </label>
+              <input
+                className="form-element"
+                id="longitude"
+                name="longitude"
+                required={true}
+                type="tel"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="btn-wrapper max-width-800"
+      >
+        <button
+          className="btn-brand btn-250 btn-submit"
+          disabled={false}
+          type="submit"
+        >
+          <span>
+            Submit Report
+          </span>
+        </button>
+      </div>
+    </form>
+  </div>
+</section>
+`;
+
+exports[`<CreateReport> should render without crashing for red-flag report 1`] = `
+<section
+  className="login-wrapper top-space account-wrapper"
+  data-pg-name="Dashboard"
+>
+  <section
+    className="heading"
+  >
+    <div
+      className="wrapper"
+      data-pg-name="Wrapper"
+    >
+      <div
+        className="max-width-800"
+      >
+        <div
+          className="bread"
+        >
+          <h1>
+            Report an Incident
+          </h1>
+        </div>
+      </div>
+    </div>
+  </section>
+  <div
+    className="wrapper"
+    data-pg-name="Wrapper"
+  >
+    <form
+      noValidate={true}
+      onSubmit={[MockFunction]}
+    >
+      <div
+        className="report-item card card-sm max-width-800 create-report-details"
+      >
+        <div
+          className="form-wrapper"
+        >
+          <label
+            htmlFor="title"
+          >
+            Title 
+          </label>
+          <small
+            className="text-helper"
+          >
+            (e.g Power outage for over 3 weeks around Aba market)
+          </small>
+          <input
+            className="form-element"
+            id="title"
+            name="title"
+            required={true}
+            type="text"
+          />
+        </div>
+        <div
+          className="form-wrapper no-margin-btm"
+        >
+          <label
+            htmlFor="comments"
+          >
+            Comment
+          </label>
+          <small
+            className="text-helper"
+          >
+            (Write full details here)
+          </small>
+          <textarea
+            className="form-element"
+            id="comments"
+            name="comment"
+            required={true}
+          />
+        </div>
+      </div>
+      <div
+        className="report-item card card-sm max-width-800 create-report-details padding-zero-btm"
+      >
+        <h2
+          className="report-box-title"
+        >
+          Report Type
+        </h2>
+        <p>
+          Is this incident linked to corruption or just an issue that needs government intervention ?
+        </p>
+        <div
+          className="row"
+          data-pg-name="Row"
+        >
+          <div
+            className="column column-md-6"
+            data-pg-name="Column"
+          >
+            <div
+              className="report-item max-width-800 report-box card no-margin-btm"
+              title="Red Flag Report"
+            >
+              <h4>
+                Corruption case
+                 
+                <i
+                  className="fa fa-flag flag"
+                  title="Red Flag Report"
+                />
+              </h4>
+              <p>
+                e.g. bribery, extortion, money laundering, e.t.c
+              </p>
+              <input
+                className="radio-fine"
+                data-pg-hidden={true}
+                defaultChecked={true}
+                defaultValue="red-flag"
+                name="type"
+                type="radio"
+              />
+              <div
+                className="pg-empty-placeholder radio-mark"
+              />
+            </div>
+          </div>
+          <div
+            className="column column-md-6"
+            data-pg-name="Column"
+          >
+            <div
+              className="report-item max-width-800 report-box card"
+              title="Intervention Report"
+            >
+              <h4>
+                Intervention Case
+                 
+                <i
+                  className="fa flag fa-bullhorn flag-intervention"
+                  title="Intervention Report"
+                />
+              </h4>
+              <p>
+                e.g. bad road, collapsed bridge, flooding, e.t.c
+              </p>
+              <input
+                className="radio-fine"
+                data-pg-hidden={true}
+                defaultChecked={false}
+                defaultValue="intervention"
+                name="type"
+                type="radio"
+              />
+              <div
+                className="pg-empty-placeholder radio-mark"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="report-item card card-sm max-width-800 create-report-details padding-zero-btm"
+      >
+        <header
+          className="header-create"
+        >
+          <h2
+            className="report-box-title"
+          >
+            Location
+          </h2>
+          <p>
+            Where did this happen? Enter the latitude/longitude. You can use
+             
+            <Link
+              replace={false}
+              target="_blank"
+              to="https://maps.google.com"
+            >
+              <strong>
+                <ins>
+                  Google Map
+                </ins>
+              </strong>
+            </Link>
+             
+            for help.
+          </p>
+          <p
+            className="hidden"
+          >
+            Where did this happen? Enter the latitude/longitude or simply use the marker to choose a location from the map
+          </p>
+        </header>
+        <div
+          className="row"
+          data-pg-name="Row"
+        >
+          <div
+            className="column-md-6 column column-xs-6"
+            data-pg-name="column-md-6"
+          >
+            <div
+              className="form-wrapper"
+            >
+              <label
+                htmlFor="latitude"
+              >
+                Latitude
+              </label>
+              <input
+                className="form-element"
+                id="latitude"
+                name="latitude"
+                required={true}
+                type="tel"
+              />
+            </div>
+          </div>
+          <div
+            className="column-md-6 column column-xs-6"
+            data-pg-name="column-md-6"
+          >
+            <div
+              className="form-wrapper"
+            >
+              <label
+                htmlFor="longitude"
+              >
+                Longitude
+              </label>
+              <input
+                className="form-element"
+                id="longitude"
+                name="longitude"
+                required={true}
+                type="tel"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="btn-wrapper max-width-800"
+      >
+        <button
+          className="btn-brand btn-250 btn-submit"
+          disabled={false}
+          type="submit"
+        >
+          <span>
+            Submit Report
+          </span>
+        </button>
+      </div>
+    </form>
+  </div>
+</section>
+`;
+
+exports[`<CreateReport> should render without crashing for successful report 1`] = `
+<section
+  className="login-wrapper top-space account-wrapper"
+  data-pg-name="Dashboard"
+>
+  <section
+    className="heading"
+  >
+    <div
+      className="wrapper"
+      data-pg-name="Wrapper"
+    >
+      <div
+        className="max-width-800"
+      >
+        <div
+          className="bread"
+        >
+          <h1>
+            Report an Incident
+          </h1>
+        </div>
+      </div>
+    </div>
+  </section>
+  <div
+    className="wrapper"
+    data-pg-name="Wrapper"
+  >
+    <form
+      noValidate={true}
+      onSubmit={[MockFunction]}
+    >
+      <Alert
+        message={
+          Array [
+            "successful",
+          ]
+        }
+        success={true}
+        title="Report Successful!"
+      />
+      <div
+        className="report-item card card-sm max-width-800 create-report-details"
+      >
+        <div
+          className="form-wrapper"
+        >
+          <label
+            htmlFor="title"
+          >
+            Title 
+          </label>
+          <small
+            className="text-helper"
+          >
+            (e.g Power outage for over 3 weeks around Aba market)
+          </small>
+          <input
+            className="form-element"
+            id="title"
+            name="title"
+            required={true}
+            type="text"
+          />
+        </div>
+        <div
+          className="form-wrapper no-margin-btm"
+        >
+          <label
+            htmlFor="comments"
+          >
+            Comment
+          </label>
+          <small
+            className="text-helper"
+          >
+            (Write full details here)
+          </small>
+          <textarea
+            className="form-element"
+            id="comments"
+            name="comment"
+            required={true}
+          />
+        </div>
+      </div>
+      <div
+        className="report-item card card-sm max-width-800 create-report-details padding-zero-btm"
+      >
+        <h2
+          className="report-box-title"
+        >
+          Report Type
+        </h2>
+        <p>
+          Is this incident linked to corruption or just an issue that needs government intervention ?
+        </p>
+        <div
+          className="row"
+          data-pg-name="Row"
+        >
+          <div
+            className="column column-md-6"
+            data-pg-name="Column"
+          >
+            <div
+              className="report-item max-width-800 report-box card no-margin-btm"
+              title="Red Flag Report"
+            >
+              <h4>
+                Corruption case
+                 
+                <i
+                  className="fa fa-flag flag"
+                  title="Red Flag Report"
+                />
+              </h4>
+              <p>
+                e.g. bribery, extortion, money laundering, e.t.c
+              </p>
+              <input
+                className="radio-fine"
+                data-pg-hidden={true}
+                defaultChecked={true}
+                defaultValue="red-flag"
+                name="type"
+                type="radio"
+              />
+              <div
+                className="pg-empty-placeholder radio-mark"
+              />
+            </div>
+          </div>
+          <div
+            className="column column-md-6"
+            data-pg-name="Column"
+          >
+            <div
+              className="report-item max-width-800 report-box card"
+              title="Intervention Report"
+            >
+              <h4>
+                Intervention Case
+                 
+                <i
+                  className="fa flag fa-bullhorn flag-intervention"
+                  title="Intervention Report"
+                />
+              </h4>
+              <p>
+                e.g. bad road, collapsed bridge, flooding, e.t.c
+              </p>
+              <input
+                className="radio-fine"
+                data-pg-hidden={true}
+                defaultChecked={true}
+                defaultValue="intervention"
+                name="type"
+                type="radio"
+              />
+              <div
+                className="pg-empty-placeholder radio-mark"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="report-item card card-sm max-width-800 create-report-details padding-zero-btm"
+      >
+        <header
+          className="header-create"
+        >
+          <h2
+            className="report-box-title"
+          >
+            Location
+          </h2>
+          <p>
+            Where did this happen? Enter the latitude/longitude. You can use
+             
+            <Link
+              replace={false}
+              target="_blank"
+              to="https://maps.google.com"
+            >
+              <strong>
+                <ins>
+                  Google Map
+                </ins>
+              </strong>
+            </Link>
+             
+            for help.
+          </p>
+          <p
+            className="hidden"
+          >
+            Where did this happen? Enter the latitude/longitude or simply use the marker to choose a location from the map
+          </p>
+        </header>
+        <div
+          className="row"
+          data-pg-name="Row"
+        >
+          <div
+            className="column-md-6 column column-xs-6"
+            data-pg-name="column-md-6"
+          >
+            <div
+              className="form-wrapper"
+            >
+              <label
+                htmlFor="latitude"
+              >
+                Latitude
+              </label>
+              <input
+                className="form-element"
+                id="latitude"
+                name="latitude"
+                required={true}
+                type="tel"
+              />
+            </div>
+          </div>
+          <div
+            className="column-md-6 column column-xs-6"
+            data-pg-name="column-md-6"
+          >
+            <div
+              className="form-wrapper"
+            >
+              <label
+                htmlFor="longitude"
+              >
+                Longitude
+              </label>
+              <input
+                className="form-element"
+                id="longitude"
+                name="longitude"
+                required={true}
+                type="tel"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="btn-wrapper max-width-800"
+      >
+        <button
+          className="btn-brand btn-250 btn-submit"
+          disabled={false}
+          type="submit"
+        >
+          <span>
+            Submit Report
+          </span>
+        </button>
+      </div>
+    </form>
+  </div>
+</section>
+`;


### PR DESCRIPTION
**What does this PR do?**
This PR enables users to create red-flag and intervention reports.

**Tasks to be completed?**
- write unit and integration tests
- add presentational and container components for creating reports
- create relevant reducers, selectors and actions
- add container component to the main route
- consume create article api endpoint

**How can this be manually tested?**
- clone the repo
- install node
- run `npm  install `
- run `npm run start:dev`
- navigate to the `/create-report` route and create a red-flag or intervention report

**Relevant PT stories?**
[#164035808](https://www.pivotaltracker.com/story/show/164035808)

**Screenshot**
N/A