### PR TITLE
#164035778 Add admin dashboard

### DIFF
--- a/src/components/containers/AdminDashboardContainer.jsx
+++ b/src/components/containers/AdminDashboardContainer.jsx
@@ -5,33 +5,31 @@ import { connect } from 'react-redux';
 import { Redirect } from 'react-router-dom';
 import { getUser, getReports, getSummary } from '../../selectors';
 import fetchReports from '../../actions/getReportAction';
-
-import UserDashboard from '../views/UserDashboard';
+import AdminDashboard from '../views/AdminDashboard';
 
 /**
- * Container component for the UserDashboard view
+ * Container component for the AdminDashboard view
  * @export
- * @class UserDashboardContainer
+ * @class AdminDashboardContainer
  * @extends {Component}
  */
-class UserDashboardContainer extends Component {
+class AdminDashboardContainer extends Component {
   componentDidMount() {
     this.handleGetReports();
   }
 
-  handleGetReports = (event) => {
-    const type = event ? event.target.value : '';
+  handleGetReports = () => {
     const { fetchReports: processFetchReports } = this.props;
-    processFetchReports(`${type}s`, type);
+    processFetchReports();
   }
 
   render() {
     const { reports, summary, user } = this.props;
-    if (!user.isLoggedIn) return <Redirect to="/login" />;
+    if (!user.isLoggedIn || !user.isAdmin) return <Redirect to="/login" />;
     return (
       reports.data
         ? (
-          <UserDashboard
+          <AdminDashboard
           reports={reports}
           summary={summary}
           active={reports.active}
@@ -43,7 +41,7 @@ class UserDashboardContainer extends Component {
   }
 }
 
-UserDashboardContainer.propTypes = {
+AdminDashboardContainer.propTypes = {
   user: PropTypes.object.isRequired,
   reports: PropTypes.object.isRequired,
   summary: PropTypes.object.isRequired,
@@ -59,7 +57,7 @@ const mapStateToProps = createStructuredSelector(
 );
 
 const mapDispatchToProps = dispatch => ({
-  fetchReports: (route, type) => dispatch(fetchReports(route, true, type)),
+  fetchReports: () => dispatch(fetchReports('incidents/admin', true, 'incidents')),
 });
 
-export default connect(mapStateToProps, mapDispatchToProps)(UserDashboardContainer);
+export default connect(mapStateToProps, mapDispatchToProps)(AdminDashboardContainer);

--- a/src/components/containers/LoginContainer.jsx
+++ b/src/components/containers/LoginContainer.jsx
@@ -29,7 +29,12 @@ class LoginContainer extends Component {
 
   render() {
     const { user } = this.props;
-    if (user.success || user.isLoggedIn) return <Redirect to="/dashboard" />;
+    if (user.isLoggedIn && !user.isAdmin) {
+      return <Redirect to="/dashboard" />
+    }
+    if (user.isLoggedIn && user.isAdmin) {
+      return <Redirect to="/admin" />
+    }
     return (
       <Login
       handleSubmit={this.handleLogin}

--- a/src/components/containers/SignupContainer.jsx
+++ b/src/components/containers/SignupContainer.jsx
@@ -28,7 +28,12 @@ class SignupContainer extends Component {
 
   render() {
     const { user } = this.props;
-    if (user.success || user.isLoggedIn) return <Redirect to="/dashboard" />;
+    if (user.isLoggedIn && !user.isAdmin) {
+      return <Redirect to="/dashboard" />;
+    }
+    if (user.isLoggedIn && user.isAdmin) {
+      return <Redirect to="/admin" />;
+    }
     return (
       <Signup
       handleSubmit={this.handleSignup}

--- a/src/components/views/AdminDashboard.jsx
+++ b/src/components/views/AdminDashboard.jsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import PropTypes from 'prop-types';
+import SummaryBox from './SummaryBox';
+import Loader from './Loader';
+import TableRow from './TableRow';
+
+/**
+ * The admin dashboard component
+ * @returns {object} The generated JSX object
+ */
+export default function AdminDashboard({
+  summary, reports
+}) {
+  const { data } = reports;
+  return (
+    <main className={`login-wrapper top-space account-wrapper relative bg-grey ${reports.isBusy && 'busy'}`}>
+      {/* Pills and Tabs */}
+      <section className="heading">
+        <div className="wrapper">
+          <div>
+            <Link to="#">
+              Reports (
+              {data.length}
+              )
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      {/* Actual content */}
+      <section className="profile-page fill-viewport">
+        <div className="wrapper">
+          <SummaryBox summary={summary} />
+
+          {/* Table */}
+          <div className="card card-sm table-overflow">
+            <div className="table-wrapper">
+              <table className="table table-striped">
+                <thead>
+                  <tr>
+                    <th>Date</th>
+                    <th>Report</th>
+                    <th>User</th>
+                    <th className="text-center">Status</th>
+                  </tr>
+                </thead>
+                <tbody id="reportsBody">
+                  {data.map(report => <TableRow report={report} key={report.id} />)}
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+
+        </div>
+      </section>
+
+      <Loader />
+    </main>
+
+  );
+}
+
+AdminDashboard.propTypes = {
+  reports: PropTypes.object.isRequired,
+  summary: PropTypes.object.isRequired
+};
+
+AdminDashboard.defaultProps = {
+};

--- a/src/components/views/TableRow.jsx
+++ b/src/components/views/TableRow.jsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import ago from 'date-fns/distance_in_words_strict';
+import DateFormat from 'date-fns/format';
+import PropTypes from 'prop-types';
+
+const getStatus = {
+  draft: { icon: 'file-text-o', class: 'draft' },
+  resolved: { icon: 'check', class: 'resolved' },
+  rejected: { icon: 'remove', class: 'rejected' },
+  'under investigation': { icon: 'info-circle', class: 'investigating' },
+};
+
+
+/**
+ * The table row component
+ * @returns {object} The generated JSX object
+ */
+export default function TableRow({ report }) {
+  const status = getStatus[report.status];
+  return (
+    <tr>
+      <td className="td-small" title={DateFormat(report.createdOn, 'MMM Do, YYYY h:mm a')}>
+        {DateFormat(report.createdOn, 'MMM Do, YYYY')}
+        <br />
+        <small>
+(
+          {`${ago(report.createdOn, new Date())} ago`}
+)
+        </small>
+      </td>
+      <td>
+        <i className={`fa flag ${report.type === 'red-flag' ? 'fa-flag flag-red-flag' : 'fa-bullhorn flag-intervention'}`} title={report.type} />
+        <Link to={`/reports/${report.type}s/${report.id}`}><ins>{report.title}</ins></Link>
+      </td>
+      <td className="relative">
+        <div className="profile-img">
+          <div className="profile-img-reports" style={{ backgroundImage: `url(${report.profile})` }} />
+        </div>
+        {' '}
+        <span className="profile-name text-capitalize">{report.firstname}</span>
+      </td>
+      <td className="text-center">
+        <span className={`badge-citizen badge-status status-badge-${status.class}`}>
+          <i className={`fa fa-${status.icon}`} />
+          {status.class}
+        </span>
+      </td>
+    </tr>
+  );
+}
+
+TableRow.propTypes = {
+  report: PropTypes.object.isRequired,
+};

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -5,9 +5,7 @@ import { ToastContainer, Flip } from 'react-toastify';
 import { BrowserRouter, Route, Switch } from 'react-router-dom';
 import { PersistGate } from 'redux-persist/lib/integration/react';
 import reduxStore from './store';
-
 import './styles/index.scss';
-
 import HeaderContainer from './components/containers/HeaderContainer';
 import Footer from './components/views/Footer';
 import Landing from './components/views/Landing';
@@ -17,9 +15,9 @@ import ProfileContainer from './components/containers/ProfileContainer';
 import CreateReportContainer from './components/containers/CreateReportContainer';
 import EditReportContainer from './components/containers/EditReportContainer';
 import UserDashboardContainer from './components/containers/UserDashboardContainer';
+import AdminDashboardContainer from './components/containers/AdminDashboardContainer';
 
 const { store, persistor } = reduxStore;
-
 
 /**
  * The main entry point of the application
@@ -38,6 +36,7 @@ function App() {
               <Route path="/sign-up" component={SignupContainer} exact />
               <Route path="/profile" component={ProfileContainer} exact />
               <Route path="/dashboard" component={UserDashboardContainer} exact />
+              <Route path="/admin" component={AdminDashboardContainer} exact />
               <Route path="/create-report" component={CreateReportContainer} exact />
               <Route path="/edit-report/:type/:id" component={EditReportContainer} exact />
               <Route path="*" component={Landing} />

--- a/src/styles/admin.scss
+++ b/src/styles/admin.scss
@@ -186,10 +186,6 @@
     margin-bottom: 40px;
 }
 
-.badge
-{
-}
-
 .status
 {
     color: rgba(255, 255, 255, 0.87);
@@ -325,3 +321,6 @@
     text-align: right;
 }
 
+.badge-status {
+    color: white
+}

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -4,7 +4,7 @@
 @import './dialog.scss';
 @import './form.scss';
 @import './login.scss';
-@import './admin.scss';
 @import './user.scss';
 @import './reports-card.scss';
 @import './toast.scss';
+@import './admin.scss';

--- a/test/containers/AdminDashboardContainer.test.js
+++ b/test/containers/AdminDashboardContainer.test.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import setup from '../setup';
+import AdminDashboardContainer from '../../src/components/containers/AdminDashboardContainer';
+
+
+describe('<AdminDashboardContainer>', () => {
+  it('should render without crashing', () => {
+    const wrapper = setup(<AdminDashboardContainer />);
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/test/containers/UserDashboardContainer.test.js
+++ b/test/containers/UserDashboardContainer.test.js
@@ -15,7 +15,8 @@ describe('<UserDashboardContainer>', () => {
   });
   it('should render without crashing when with data', () => {
     mockState.reports.data = [{
-      status: 'draft'
+      status: 'draft',
+      id: 1
     }];
     const wrapper = setup(<UserDashboardContainer />, mockState);
     expect(wrapper).toMatchSnapshot();

--- a/test/containers/__snapshots__/AdminDashboardContainer.test.js.snap
+++ b/test/containers/__snapshots__/AdminDashboardContainer.test.js.snap
@@ -1,0 +1,76 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<AdminDashboardContainer> should render without crashing 1`] = `
+<Provider
+  store={
+    Object {
+      "clearActions": [Function],
+      "dispatch": [Function],
+      "getActions": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+    }
+  }
+>
+  <BrowserRouter
+    keyLength={0}
+  >
+    <Router
+      history={
+        Object {
+          "action": "REPLACE",
+          "block": [Function],
+          "createHref": [Function],
+          "go": [Function],
+          "goBack": [Function],
+          "goForward": [Function],
+          "length": 1,
+          "listen": [Function],
+          "location": Object {
+            "hash": "",
+            "pathname": "/login",
+            "search": "",
+            "state": undefined,
+          },
+          "push": [Function],
+          "replace": [Function],
+        }
+      }
+    >
+      <Connect(AdminDashboardContainer)>
+        <AdminDashboardContainer
+          fetchReports={[Function]}
+          reports={
+            Object {
+              "data": Array [],
+              "isBusy": false,
+              "success": false,
+            }
+          }
+          summary={
+            Object {
+              "investigating": 0,
+              "pending": 0,
+              "rejected": 0,
+              "resolved": 0,
+            }
+          }
+          user={
+            Object {
+              "isBusy": false,
+              "message": Array [],
+              "success": false,
+            }
+          }
+        >
+          <Redirect
+            push={false}
+            to="/login"
+          />
+        </AdminDashboardContainer>
+      </Connect(AdminDashboardContainer)>
+    </Router>
+  </BrowserRouter>
+</Provider>
+`;

--- a/test/containers/__snapshots__/UserDashboardContainer.test.js.snap
+++ b/test/containers/__snapshots__/UserDashboardContainer.test.js.snap
@@ -324,6 +324,7 @@ exports[`<UserDashboardContainer> should render without crashing when with data 
             Object {
               "data": Array [
                 Object {
+                  "id": 1,
                   "status": "draft",
                 },
               ],
@@ -355,6 +356,7 @@ exports[`<UserDashboardContainer> should render without crashing when with data 
               Object {
                 "data": Array [
                   Object {
+                    "id": 1,
                     "status": "draft",
                   },
                 ],
@@ -546,8 +548,10 @@ exports[`<UserDashboardContainer> should render without crashing when with data 
                       id="results"
                     >
                       <ReportCard
+                        key="1"
                         report={
                           Object {
+                            "id": 1,
                             "status": "draft",
                           }
                         }
@@ -600,11 +604,11 @@ exports[`<UserDashboardContainer> should render without crashing when with data 
                               <Link
                                 className="report-item-link"
                                 replace={false}
-                                to="/report/undefineds/undefined"
+                                to="/report/undefineds/1"
                               >
                                 <a
                                   className="report-item-link"
-                                  href="/report/undefineds/undefined"
+                                  href="/report/undefineds/1"
                                   onClick={[Function]}
                                 >
                                   Details
@@ -616,11 +620,11 @@ exports[`<UserDashboardContainer> should render without crashing when with data 
                               <Link
                                 className="btn-brand btn-secondary"
                                 replace={false}
-                                to="/edit-report/undefineds/undefined"
+                                to="/edit-report/undefineds/1"
                               >
                                 <a
                                   className="btn-brand btn-secondary"
-                                  href="/edit-report/undefineds/undefined"
+                                  href="/edit-report/undefineds/1"
                                   onClick={[Function]}
                                 >
                                   Edit

--- a/test/views/AdminDashboard.test.js
+++ b/test/views/AdminDashboard.test.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import AdminDashboard from '../../src/components/views/AdminDashboard';
+
+const props = {
+  reports: {
+    data: [{
+      id: 1
+    }]
+  },
+  summary: {}
+};
+
+describe('<AdminDashboard>', () => {
+  it('should render without crashing', () => {
+    const wrapper = shallow(<AdminDashboard {...props} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+  it('should render without crashing when busy', () => {
+    props.reports.isBusy = true;
+    const wrapper = shallow(<AdminDashboard {...props} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/test/views/TableRow.test.js
+++ b/test/views/TableRow.test.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import TableRow from '../../src/components/views/TableRow';
+
+const report = {
+  status: 'draft',
+  type: 'red-flag'
+};
+
+describe('<TableRow>', () => {
+  it('should render without crashing', () => {
+    const wrapper = shallow(<TableRow report={report} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+  it('should render without crashing for intervention reports', () => {
+    report.type = 'intervention';
+    const wrapper = shallow(<TableRow report={report} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/test/views/__snapshots__/AdminDashboard.test.js.snap
+++ b/test/views/__snapshots__/AdminDashboard.test.js.snap
@@ -1,0 +1,159 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<AdminDashboard> should render without crashing 1`] = `
+<main
+  className="login-wrapper top-space account-wrapper relative bg-grey undefined"
+>
+  <section
+    className="heading"
+  >
+    <div
+      className="wrapper"
+    >
+      <div>
+        <Link
+          replace={false}
+          to="#"
+        >
+          Reports (
+          1
+          )
+        </Link>
+      </div>
+    </div>
+  </section>
+  <section
+    className="profile-page fill-viewport"
+  >
+    <div
+      className="wrapper"
+    >
+      <SummaryBox
+        summary={Object {}}
+      />
+      <div
+        className="card card-sm table-overflow"
+      >
+        <div
+          className="table-wrapper"
+        >
+          <table
+            className="table table-striped"
+          >
+            <thead>
+              <tr>
+                <th>
+                  Date
+                </th>
+                <th>
+                  Report
+                </th>
+                <th>
+                  User
+                </th>
+                <th
+                  className="text-center"
+                >
+                  Status
+                </th>
+              </tr>
+            </thead>
+            <tbody
+              id="reportsBody"
+            >
+              <TableRow
+                key="1"
+                report={
+                  Object {
+                    "id": 1,
+                  }
+                }
+              />
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </section>
+  <Loader />
+</main>
+`;
+
+exports[`<AdminDashboard> should render without crashing when busy 1`] = `
+<main
+  className="login-wrapper top-space account-wrapper relative bg-grey busy"
+>
+  <section
+    className="heading"
+  >
+    <div
+      className="wrapper"
+    >
+      <div>
+        <Link
+          replace={false}
+          to="#"
+        >
+          Reports (
+          1
+          )
+        </Link>
+      </div>
+    </div>
+  </section>
+  <section
+    className="profile-page fill-viewport"
+  >
+    <div
+      className="wrapper"
+    >
+      <SummaryBox
+        summary={Object {}}
+      />
+      <div
+        className="card card-sm table-overflow"
+      >
+        <div
+          className="table-wrapper"
+        >
+          <table
+            className="table table-striped"
+          >
+            <thead>
+              <tr>
+                <th>
+                  Date
+                </th>
+                <th>
+                  Report
+                </th>
+                <th>
+                  User
+                </th>
+                <th
+                  className="text-center"
+                >
+                  Status
+                </th>
+              </tr>
+            </thead>
+            <tbody
+              id="reportsBody"
+            >
+              <TableRow
+                key="1"
+                report={
+                  Object {
+                    "id": 1,
+                  }
+                }
+              />
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </section>
+  <Loader />
+</main>
+`;

--- a/test/views/__snapshots__/TableRow.test.js.snap
+++ b/test/views/__snapshots__/TableRow.test.js.snap
@@ -1,0 +1,123 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<TableRow> should render without crashing 1`] = `
+<tr>
+  <td
+    className="td-small"
+    title="Invalid Date"
+  >
+    Invalid Date
+    <br />
+    <small>
+      (
+      NaN years ago
+      )
+    </small>
+  </td>
+  <td>
+    <i
+      className="fa flag fa-flag flag-red-flag"
+      title="red-flag"
+    />
+    <Link
+      replace={false}
+      to="/reports/red-flags/undefined"
+    >
+      <ins />
+    </Link>
+  </td>
+  <td
+    className="relative"
+  >
+    <div
+      className="profile-img"
+    >
+      <div
+        className="profile-img-reports"
+        style={
+          Object {
+            "backgroundImage": "url(undefined)",
+          }
+        }
+      />
+    </div>
+     
+    <span
+      className="profile-name text-capitalize"
+    />
+  </td>
+  <td
+    className="text-center"
+  >
+    <span
+      className="badge-citizen badge-status status-badge-draft"
+    >
+      <i
+        className="fa fa-file-text-o"
+      />
+      draft
+    </span>
+  </td>
+</tr>
+`;
+
+exports[`<TableRow> should render without crashing for intervention reports 1`] = `
+<tr>
+  <td
+    className="td-small"
+    title="Invalid Date"
+  >
+    Invalid Date
+    <br />
+    <small>
+      (
+      NaN years ago
+      )
+    </small>
+  </td>
+  <td>
+    <i
+      className="fa flag fa-bullhorn flag-intervention"
+      title="intervention"
+    />
+    <Link
+      replace={false}
+      to="/reports/interventions/undefined"
+    >
+      <ins />
+    </Link>
+  </td>
+  <td
+    className="relative"
+  >
+    <div
+      className="profile-img"
+    >
+      <div
+        className="profile-img-reports"
+        style={
+          Object {
+            "backgroundImage": "url(undefined)",
+          }
+        }
+      />
+    </div>
+     
+    <span
+      className="profile-name text-capitalize"
+    />
+  </td>
+  <td
+    className="text-center"
+  >
+    <span
+      className="badge-citizen badge-status status-badge-draft"
+    >
+      <i
+        className="fa fa-file-text-o"
+      />
+      draft
+    </span>
+  </td>
+</tr>
+`;


### PR DESCRIPTION
**What does this PR do?**
This PR enables adds an admin dashboard to the application that enables admin to view stats of all reports and also change the status of a report

**Tasks to be completed?**
- write unit and integration tests
- create table row component
- create admin dashboard component
- consume api endpoints to get red-flag and intervention reports from all users
- add admin dahboard component to main route

**How can this be manually tested?**
- clone the repo
- install node
- run `npm  install `
- run `npm run start:dev`
- navigate to the `/dashboard`.

**Relevant PT stories?**
[#164035778](https://www.pivotaltracker.com/story/show/164035778)

**Screenshot**
N/A